### PR TITLE
added CSS class to hide the Clinics related menus in admin panel

### DIFF
--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -121,11 +121,11 @@
                     <a href="{{ route('admin.dashboard') }}" class="list-group-item list-group-item-action {{ Route::currentRouteName() == 'admin.dashboard' ? 'active' : '' }}">
                         <i class="fa fa-pie-chart mr-3"></i>Dashboard
                     </a>
-                    <a href="{{ route('admin.clinic-list') }}" class="list-group-item list-group-item-action {{ Route::currentRouteName() == 'admin.clinic-list' ? 'active' : '' }}">
+                    <a href="{{ route('admin.clinic-list') }}" class="d-none list-group-item list-group-item-action {{ Route::currentRouteName() == 'admin.clinic-list' ? 'active' : '' }}">
                         <i class="fa fa-plus-square mr-3"></i>Lista Clinici</a>
-                    <a href="{{ route('admin.clinic-add') }}" class="list-group-item list-group-item-action sub-list {{ Route::currentRouteName() == 'admin.clinic-add' ? 'active' : '' }}">
+                    <a href="{{ route('admin.clinic-add') }}" class="d-none list-group-item list-group-item-action sub-list {{ Route::currentRouteName() == 'admin.clinic-add' ? 'active' : '' }}">
                         <i class="fa fa-plus-square invisible mr-3"></i>Adauga o clinica</a>
-                    <a href="{{ route('admin.clinic-category-list') }}" class="list-group-item list-group-item-action sub-list {{ in_array(Route::currentRouteName(), ['admin.clinic-category-list', 'admin.clinic-category-add', 'admin.clinic-category-edit']) ? 'active' : '' }}">
+                    <a href="{{ route('admin.clinic-category-list') }}" class="d-none list-group-item list-group-item-action sub-list {{ in_array(Route::currentRouteName(), ['admin.clinic-category-list', 'admin.clinic-category-add', 'admin.clinic-category-edit']) ? 'active' : '' }}">
                         <i class="fa fa-plus-square invisible mr-3"></i>Categorii clinici</a>
                     <a href="{{ route('admin.help-list') }}" class="list-group-item list-group-item-action {{ in_array(Route::currentRouteName(), ['admin.help-list', 'admin.help-detail']) ? 'active' : '' }}">
                         <i class="fa fa-exclamation-triangle mr-3"></i>Cereri de ajutor</a>


### PR DESCRIPTION
### What does it fix?

Closes https://github.com/code4romania/war-support-un-acoperis/issues/10

Added CSS class to hide the Clinics related menus in admin panel

### How has it been tested?

Refreshed the admin page. The Clinics related menus are not visible anymore.
