### PR TITLE
make the docker-compose.yml backwards compatible with docker-compose v1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     container_name: helpforhealth_web
     build:
       dockerfile: .docker/webserver/Dockerfile
+      context: .docker/webserver
     volumes:
       - ./:/app
     links:


### PR DESCRIPTION
fixes issues when working with the docker-compose cli tool v1 & v2