### PR TITLE
Saving files before refreshing line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 *.scss linguist-vendored
 *.js linguist-vendored
 CHANGELOG.md export-ignore
+
+# Ensure all .sh and PHP files use LF.
+*.php eol=lf
+*.sh eol=lf


### PR DESCRIPTION
### Requirements for making a pull request

Thank you for contributing to our project! 

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.

### What does it fix?

it enforces git to use lf line endings across all environments.
For some reason crlf was added for windows users for the entrypoint.sh used to build the web docker container which caused it to crash.

There's another similar rule in the .editorconfig in the base path of the application but apparently it's ignored by some IDE's.

Setting it in git should solve the problem.

Closes <!-- If it is related to an open issue, please link the issue here. -->

Please mention the main changes this PR brings.

### How has it been tested?

Was able to build the docker containers on a windows machine after adding the file line endings assignments in the .gitattributes file

<!-- If applicable, mention any known issues with the pull request -->
