### PR TITLE
auto-update help request status on allocation

### DIFF
--- a/app/HelpRequest.php
+++ b/app/HelpRequest.php
@@ -86,6 +86,11 @@ class HelpRequest extends Model implements Auditable
         return $this->belongsToMany(Accommodation::class, 'allocations', 'help_request_id', 'accommodation_id');
     }
 
+    public function isCompleted(): bool
+    {
+        return $this->accommodation()->sum('number_of_guest') == $this->guests_number;
+    }
+
     public function isAllocated(): bool
     {
         return $this->accommodation()->exists();

--- a/resources/lang/ro.json
+++ b/resources/lang/ro.json
@@ -447,6 +447,8 @@
     "Guests number": "Număr persoane",
     "A partnership with": "Un proiect în parteneriat cu",
     "made by": "realizat de",
+    "There is no help request with this number": "Nu exista solicitare de cazare cu acest numar.",
+    "This help request is already resolved": "Cererea de cazare este deja rezolvata complet.",
     "You have successfully registered": "Te-ai înregistrat cu succes",
     "Thank you for your generosity": "Îți mulțumim pentru generozitate",
     "You will be contacted": "Vei fi contactat fie telefonic, fie în persoană, de un reprezentant al autorităților pentru a verifica informația pe care ne-ai furnizat-o. Între timp ți-am trimis pe email o copie a formularului pe care l-ai completat și un link pentru a putea să îți accesezi contul creat în platformă pentru a vedea statusul ofertei tale.",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -445,6 +445,8 @@
     "I need special transport (e.g. car with wheelchair space)": "Мне нужен специальный транспорт (например, автомобиль с местом для инвалидной коляски)",
     "A partnership with": "Проект в партнерстве",
     "made by": "реализовано",
+    "There is no help request with this number": "There is no help request with this number",
+    "This help request is already resolved": "This help request is already resolved",
     "Hotel/Guesthouse": "Отель/гостевой дом",
     "Other spaces": "Другие места",
     "Offer accommodation": "Предоставляй жилье",

--- a/resources/lang/uk.json
+++ b/resources/lang/uk.json
@@ -444,6 +444,8 @@
     "I need special transport (e.g. car with wheelchair space)": "Мені потрібен спеціальний транспорт (наприклад, автомобіль з місцем для інвалідних візків)",
     "A partnership with": "Проект у партнерстві з",
     "made by": "створено",
+    "There is no help request with this number": "There is no help request with this number",
+    "This help request is already resolved": "This help request is already resolved",
     "Hotel/Guesthouse": "Готель/Гостьовий будинок",
     "Other spaces": "Інші простори",
     "Offer accommodation": "Надай житло",

--- a/resources/views/partials/forms/accommodation-help-requests-full.blade.php
+++ b/resources/views/partials/forms/accommodation-help-requests-full.blade.php
@@ -29,6 +29,7 @@
                 <thead class="thead-dark">
                 <tr>
                     <th>{{ __('Refugee name') }}</th>
+                    <th>{{ __('Help request') }}</th>
                     <th>{{ __('Number of people') }}</th>
                     <th>{{ __('Allocation date') }}</th>
                     <th>{{ __('Updated at') }}</th>
@@ -72,6 +73,7 @@
                 $.each(responseData, function (key, value) {
                     let row = '<tr>\n' +
                         '    <td>' + value.name + '</td>\n' +
+                        '    <td><a href="/{{ $area }}/help-request/' + value.id + '">#' + value.id + '</a></td>\n' +
                         '    <td>' + value.number_of_guest + '</td>\n' +
                         '    <td>' + value.created_at + '</td>\n' +
                         '    <td>' + value.updated_at + '</td>\n' +


### PR DESCRIPTION
…on capacity/usage based on actually allocated

### Requirements for making a pull request

Thank you for contributing to our project! 

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.

### What does it fix?

When a help request is allocated to an accommodation, the status should be updated automatically.
Also, the accommodation capacity should be calculated using the actual allocated guests, and not by help requests total guests.


### How has it been tested?
- on the admin page allow allocation of a help request multiple times.
- on the admin page display the actual allocated guests
