### PR TITLE
WAR-155 added support for uploading ID attachment during host creation

### DIFF
--- a/app/Http/Controllers/Admin/HostController.php
+++ b/app/Http/Controllers/Admin/HostController.php
@@ -99,6 +99,7 @@ class HostController extends Controller
 
         return view('admin.host-detail')
             ->with('user', $user)
+            ->with('host_id_url', $user->idDoc()->first()->generateUrl())
             ->with('accommodations', $accommodations);
     }
 

--- a/app/Http/Controllers/GetInvolvedController.php
+++ b/app/Http/Controllers/GetInvolvedController.php
@@ -94,7 +94,17 @@ class GetInvolvedController extends Controller
      */
     public function storePersonAccount(HostRequestPerson $request)
     {
-        $this->createHost($request);
+        try {
+            $this->createHost($request);
+        }
+        catch (\Throwable $throwable)
+        {
+            if ($request instanceof HostRequestCompany)
+                return Redirect::back()->withInput()->withErrors(['cui_document' => $throwable->getMessage()]);
+            else
+                return Redirect::back()->withInput()->withErrors(['id_document' => $throwable->getMessage()]);
+        }    
+
         return redirect()->route('get-involved-add-accommodation-form');
     }
 

--- a/app/Http/Controllers/Host/ProfileController.php
+++ b/app/Http/Controllers/Host/ProfileController.php
@@ -42,7 +42,8 @@ class ProfileController extends Controller
         }
 
         return view('host.profile')
-            ->with('user', $user);
+            ->with('user', $user)
+            ->with('host_id_url', $user->idDoc()->first()->generateUrl());
     }
 
     /**

--- a/app/Http/Requests/HostRequestCompany.php
+++ b/app/Http/Requests/HostRequestCompany.php
@@ -36,6 +36,7 @@ class HostRequestCompany extends FormRequest
             'new_user.phone' => ['required', 'max:18', 'min:10', 'regex:/^([0-9\s\ \-\+\(\)]*)$/'],
             'new_user.email' => ['required', 'email', 'min:5', 'max:64', 'unique:users,email'],
             'new_user.other' => ['nullable', 'string', 'min:2', 'max:256'],
+            'cui_document' => ['required', 'mimes:jpg,jpeg,png'],
         ];
 
         if (Route::currentRouteName() == 'store-get-involved') {
@@ -63,6 +64,7 @@ class HostRequestCompany extends FormRequest
             'new_user.phone' => __("Phone Number"),
             'new_user.email' => __("E-Mail Address"),
             'new_user.other' => __('Other type'),
+            'cui_document' => __('CUI Document'),
         ];
     }
 }

--- a/app/Http/Requests/HostRequestPerson.php
+++ b/app/Http/Requests/HostRequestPerson.php
@@ -33,6 +33,7 @@ class HostRequestPerson extends FormRequest
             'new_user.phone' => ['required', 'max:18', 'min:10', 'regex:/^([0-9\s\ \-\+\(\)]*)$/'],
             'new_user.email' => ['required', 'email', 'min:5', 'max:64', 'unique:users,email'],
             'new_user.other' => ['nullable', 'string', 'min:2', 'max:256'],
+            'id_document' => ['required', 'mimes:jpg,jpeg,png'],
         ];
 
         if (Route::currentRouteName() == 'store-get-involved') {
@@ -57,6 +58,7 @@ class HostRequestPerson extends FormRequest
             'new_user.phone' => __("Phone Number"),
             'new_user.email' => __("E-Mail Address"),
             'new_user.other' => __('Other type'),
+            'id_document' => __('ID Document'),
         ];
     }
 }

--- a/app/Services/HostService.php
+++ b/app/Services/HostService.php
@@ -26,23 +26,9 @@ class HostService
         $userService = new UserService();
         $user = $userService->createHostUser($request);
 
-        $this->generateResetTokenAndNotifyUser($user);
+        $userService->generateResetTokenAndNotifyUser($user);
 
         return $user;
-    }
-
-    /**
-     * @param User $user
-     * @return void
-     */
-    private function generateResetTokenAndNotifyUser(User $user): void
-    {
-        $resetToken = Password::getRepository()->create($user);
-
-        $notification = new UserCreatedNotification($user, $resetToken);
-
-        Notification::route('mail', $user->email)
-            ->notify($notification);
     }
 
     public function viewSignupForm(string $view, ?string $description = null)

--- a/app/User.php
+++ b/app/User.php
@@ -36,6 +36,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property string|null $phone_number
  * @property ?DateTime $approved_at
  * @property ?HasMany $helpRequest
+ * @property ?HasOne $idDoc
  */
 class User extends Authenticatable implements Auditable
 {
@@ -98,6 +99,11 @@ class User extends Authenticatable implements Auditable
     public function accommodations(): HasMany
     {
         return $this->hasMany(Accommodation::class);
+    }
+
+    public function idDoc(): HasOne
+    {
+        return $this->hasOne(UserAttachment::class);
     }
 
     public function helpRequest(): HasMany

--- a/app/UserAttachment.php
+++ b/app/UserAttachment.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class UserAttachment
+ * @package App
+ *
+ * @property int $id
+ * @property int $user_id
+ * @property string $name
+ * @property string $identifier
+ * @property string $path
+ * @property int $size
+ * @property string|null $extension
+ * @property string|null $type
+ */
+
+class UserAttachment extends Model
+{
+    /**
+     * @return string
+     */
+    public function generateUrl(): string
+    {
+        return route('media.attachment-content', ['docType' => get_class($this), 'docId' => $this->id, 
+            'identifier' => $this->identifier, 'extension' => substr($this->extension, 1)]);
+    }
+
+    /**
+     * @return BelongsTo
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2022_03_09_110859_create_user_attachments_table.php
+++ b/database/migrations/2022_03_09_110859_create_user_attachments_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserAttachmentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_attachments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('name', 255);
+            $table->string('identifier', 64)->nullable()->index();
+            $table->string('path', 255);
+            $table->unsignedMediumInteger('size');
+            $table->string('extension', 5)->nullable();
+            $table->string('type', 64)->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_attachments');
+    }
+}

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -43,3 +43,8 @@ template {
     }
   }
 }
+
+.fileuploader.fileuploader-theme-default {
+  padding: 0px;
+  margin: 0px;
+}

--- a/resources/views/host/profile.blade.php
+++ b/resources/views/host/profile.blade.php
@@ -61,6 +61,14 @@
                     {{ $user->email }}
                 </p>
             </div>
+            <div class="kv d-flex">
+                <b class="mr-3">
+                    {{ __('Host ID') }}
+                </b>
+                <div class="gallery d-flex flex-wrap mb-4">
+                    <a href="{{ $host_id_url }}" data-toggle="lightbox"><img src="{{ $host_id_url }}" alt="photo" class="img-fluid"></a>
+                </div>
+            </div>
         </div>
     </div>
     <div class="card shadow">

--- a/resources/views/partials/forms/host-signup-base.blade.php
+++ b/resources/views/partials/forms/host-signup-base.blade.php
@@ -37,6 +37,23 @@
     }
 
     $(document).ready(function(){
+        $('input[name="id_document"]').fileuploader({
+            captions: $('html').attr('lang'),
+            limit: 1,
+            maxSize: 1,
+            extensions: ['png', 'jpg', 'jpeg'],
+            enableApi: true,
+            addMore: true,
+        });
+        $('input[name="cui_document"]').fileuploader({
+            captions: $('html').attr('lang'),
+            limit: 1,
+            maxSize: 1,
+            extensions: ['png', 'jpg', 'jpeg'],
+            enableApi: true,
+            addMore: true,
+        });
+
         showHideHostForms();
 
         $('#host_type').on('change', function (){

--- a/resources/views/partials/forms/host-signup-company.blade.php
+++ b/resources/views/partials/forms/host-signup-company.blade.php
@@ -1,4 +1,4 @@
-<form method="POST" action="{{ $formRouteCompany }}" id="hostSignupCompanyForm">
+<form method="POST" action="{{ $formRouteCompany }}" id="hostSignupCompanyForm" enctype="multipart/form-data">
     @csrf
     <input type="hidden" name="new_user[host_type_copy]" value="{{ $hostType }}" />
 
@@ -12,6 +12,16 @@
                 <span class="invalid-feedback" role="alert">{{ $message }}</span>
                 @enderror
             </div>
+        </div>
+        <div class="col-sm-6">
+            <label for="id_document" class="font-weight-600 required">
+                {{ __('Upload your CUI') }}:
+            </label>
+            <input type="file" id="cui_document" name="cui_document"/>
+
+            @error('cui_document')
+            <span class="invalid-feedback" role="alert">{{ $message }}</span>
+            @enderror
         </div>
     </div>
     <div class="row">

--- a/resources/views/partials/forms/host-signup-person.blade.php
+++ b/resources/views/partials/forms/host-signup-person.blade.php
@@ -1,4 +1,4 @@
-<form method="POST" action="{{ $formRoutePerson }}" id="hostSignupPersonForm">
+<form method="POST" action="{{ $formRoutePerson }}" id="hostSignupPersonForm" enctype="multipart/form-data">
     @csrf
     <input type="hidden" name="new_user[host_type_copy]" value="{{ $hostType }}" />
 
@@ -31,6 +31,16 @@
                 <span class="invalid-feedback" role="alert">{{ $message }}</span>
                 @enderror
             </div>
+        </div>
+        <div class="col-sm-6">
+            <label for="id_document" class="font-weight-600 required">
+                {{ __('Upload your ID') }}:
+            </label>
+            <input type="file" id="id_document" name="id_document"/>
+
+            @error('id_document')
+            <span class="invalid-feedback" role="alert">{{ $message }}</span>
+            @enderror
         </div>
     </div>
 

--- a/resources/views/partials/user-detail.blade.php
+++ b/resources/views/partials/user-detail.blade.php
@@ -59,6 +59,14 @@
                 {{ $user->email }}
             </p>
         </div>
+        <div class="kv d-flex">
+            <b class="mr-3">
+                {{ __('Host ID') }}
+            </b>
+            <div class="gallery d-flex flex-wrap mb-4">
+                <a href="{{ $host_id_url }}" data-toggle="lightbox"><img src="{{ $host_id_url }}" alt="photo" class="img-fluid"></a>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,14 @@ Route::get('/media/accommodation/{accommodationId}/{identifier}.{extension}', 'M
     ->middleware('auth');
 
 /**
+ * Attachment handling
+ */
+Route::get('/media/attachment/{docType}/{docId}/{identifier}.{extension}', 'MediaController@attachmentContent')
+    ->where('docId', '[0-9]+')
+    ->name('media.attachment-content')
+    ->middleware('auth');    
+
+/**
  * Administration routes
  */
 Route::middleware([ShareMiddleware::class])->prefix('/share')->group(function (){


### PR DESCRIPTION
### Requirements for making a pull request

Thank you for contributing to our project! 

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.

### What does it fix?

Closes #155

Please mention the main changes this PR brings.
* new class and storage added for user attachments, links 1-to-1 with user object
* modified host get-involved form to allow file upload into the user attachment object
![image](https://user-images.githubusercontent.com/15802257/157448326-42aa7eb8-af91-46a0-b56d-1191ae198b0b.png)

* some commented ground work on MediaController to unify rendering of accommodation-photos in 1 method - needs further discussion
* MediaController support for accomodation-photos might need extra checks to prevent other users downloading files if they have a link

### Known Issues
* need some help from to solve why errors related to the fileuploaded field are not showing up next to it

### Open Questions
* Should host be able to edit his photo ID during profile edit?
* Should admin be able to edit host photo ID during profile edit?
* Does trusted user need access to view or edit host photo ID?

### How has it been tested?

Please describe the tests that you ran to verify your changes.

local testing using local storage
create&view new host person and host company on get involved
create new host person and host company from admin
view host person and host company profile by admin
