### PR TITLE
Fix install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,9 @@ generate-key:
 .PHONY: npm-watch
 npm-watch:
 	docker-compose run --rm nodejs sh -c 'npm run watch'
+
+.PHONY: clean
+clean:
+	$(shell test ! -e .env && cp .env.example .env)
+	docker-compose down --volumes --remove-orphans --rmi=all
+	git clean -fdx -e .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       PHP_OPCACHE_ENABLE: 0
     volumes:
-      - ./:/var/html:delegated
+      - ./:/var/www:delegated
     ports:
       - "80:8080"
     depends_on:


### PR DESCRIPTION
After switching to `main` branch, I decided to start fresh and removed everything since my branch diverged quite a lot.

I run the commands that I introduced in `make clean`.

Then calling `make install` failed with:
```
docker-compose exec php sh -c 'composer install'
Composer could not find a composer.json file in /var/www/html
To initialize a project, please create a composer.json file. See https://getcomposer.org/basic-usage
```

After rebuilding the cached docker images, another error showed up running `docker-compose exec php sh -c 'php artisan key:generate'`
```
[2022-03-12 15:16:19] local.ERROR: file_get_contents(/var/www/.env): failed to open stream: No such file or directory {"exception":"[object] (ErrorException(code: 0): file_get_contents(/var/www/.env): failed to open stream: No such file or directory at /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Console/KeyGenerateCommand.php:96)
```

It turns out, that the volume was mounted on `/var/html` after #238 but the workdir was expected to be in `/var/www`.

### What does it fix?

Fixes `make install` and introduces a new make command to start from a fresh checkout (useful when upstream diverged a lot from your own branch).

### How has it been tested?

You can reproduce the error by:
1. `git checkout fix-install~`
2. `make clean`
3. `make install`

Then to confirm the fix you need to:
1. `git checkout fix-install`
2. `make clean`
3. `make install`